### PR TITLE
Fix HTML attribute typo and update maintenance guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,11 @@ This repository contains the static web site for DIVERSION RP. Keep this file up
    ```bash
    php -l db.php posts.php send_email.php showcase.php
    ```
-5. Add additional testing tools as needed and document them here.
+5. Validate HTML markup using **tidy**:
+   ```bash
+   tidy -qe *.html
+   ```
+6. Add additional testing tools as needed and document them here.
 
 ## Notes
 - Ensure JetBrains IDEs open the project without build errors.

--- a/rules.html
+++ b/rules.html
@@ -826,7 +826,7 @@
 
                 <!-- Collapsible Section: Gang Rules -->
                 <div class="mb-2">
-                    <h3 class="text-xl font-semibold bg-gray-800 p-3 cursor-pointer rounded-lg" rounded-lg" data-accordion="subsection42">
+                    <h3 class="text-xl font-semibold bg-gray-800 p-3 cursor-pointer rounded-lg" data-accordion="subsection42">
                         Elite Status
                     </h3>
                     <div id="subsection42" class="collapsible-content hidden p-3 bg-gray-600 border-2 border-gray-500 rounded-lg shadow-lg">


### PR DESCRIPTION
## Summary
- fix a misquoted attribute on the Gang Rules section in **rules.html**
- document HTML linting with `tidy` in AGENTS

## Testing
- `pnpm install`
- `pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css`
- `php -l db.php posts.php send_email.php showcase.php`


------
https://chatgpt.com/codex/tasks/task_e_685f5d0a18b883308973e07dea0cacdd