### PR TITLE
Upgrade Tailwind CSS and integrate HeroUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,19 +15,23 @@ This repository contains the static web site for DIVERSION RP. Keep this file up
    ```bash
    pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css
    ```
-4. Build the React/Laravel frontend after any JS or PHP change:
+4. Install HeroUI components for React:
+   ```bash
+   pnpm add @heroui/react@beta --dir diversionrp-laravel
+   ```
+5. Build the React/Laravel frontend after any JS or PHP change:
    ```bash
    pnpm run build --dir diversionrp-laravel
    ```
-5. Lint PHP scripts:
+6. Lint PHP scripts:
    ```bash
    php -l db.php posts.php showcase.php
    ```
-6. Validate HTML markup using **tidy**:
+7. Validate HTML markup using **tidy**:
    ```bash
    tidy -qe *.html
    ```
-7. The Laravel skeleton lives in `diversionrp-laravel`. If missing, scaffold it:
+8. The Laravel skeleton lives in `diversionrp-laravel`. If missing, scaffold it:
    ```bash
    composer create-project laravel/laravel diversionrp-laravel
    ```
@@ -38,15 +42,15 @@ This repository contains the static web site for DIVERSION RP. Keep this file up
    cp diversionrp-laravel/.env.example diversionrp-laravel/.env
    php artisan key:generate --working-dir=diversionrp-laravel
    ```
-8. Run Laravel tests:
+9. Run Laravel tests:
    ```bash
    cd diversionrp-laravel && php artisan test
    ```
-9. Launch the React/Vite dev server:
+10. Launch the React/Vite dev server:
    ```bash
    pnpm run dev --dir diversionrp-laravel
    ```
-10. Add additional testing tools as needed and document them here.
+11. Add additional testing tools as needed and document them here.
 
 ## Notes
 - Ensure JetBrains IDEs open the project without build errors.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Diversion RP Website
 
-Static website with PHP scripts and Tailwind CSS. A lightweight SQLite database powers dynamic announcements. Phase 3 begins the move to a Laravel + React stack. The old static HTML pages (home, contact, rules, streams, showcase and support) have been removed and replaced with React components served by Laravel routes.
+Static website with PHP scripts and **Tailwind CSS 4**. A lightweight SQLite database powers dynamic announcements. Phase 3 begins the move to a Laravel + React stack. The old static pages now live as React components served by Laravel routes. UI elements are gradually being replaced by **HeroUI** components.
 
 ## Build CSS
 ```bash
 pnpm install
+pnpm add @heroui/react@beta --dir diversionrp-laravel
 pnpm exec tailwindcss -i ./src/styles.css -o ./dist/styles.css
 pnpm run build --dir diversionrp-laravel
 ```

--- a/diversionrp-laravel/package.json
+++ b/diversionrp-laravel/package.json
@@ -16,6 +16,7 @@
         "vite": "^6.2.4"
     },
     "dependencies": {
+        "@heroui/react": "2.8.0-beta.10",
         "react": "18.2.0",
         "react-dom": "18.2.0"
     }

--- a/diversionrp-laravel/pnpm-lock.yaml
+++ b/diversionrp-laravel/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@heroui/react':
+        specifier: 2.8.0-beta.10
+        version: 2.8.0-beta.10(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(tailwindcss@4.1.11)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -109,6 +112,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -272,6 +279,586 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+
+  '@heroui/accordion@2.2.19-beta.2':
+    resolution: {integrity: sha512-HNxHZtFkNzNd21U9j+iLs083zFBb36OB6lSbjnO+E19DPkuLG5c191rAGuPWPXH5ZfPOQm+FB4c0mgdiVL4euA==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/alert@2.2.22-beta.2':
+    resolution: {integrity: sha512-jBleMR6xlx89rdiMoOLlKj43MaSL4ohXiQNfqolz+siKQap2T1l4ufNhnEGzIEGkgIHvfMSJRgYCyJ95SNL6EQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/aria-utils@2.2.19-beta.2':
+    resolution: {integrity: sha512-QYsfZ2FEJxomeV9xX0CLLtNQyrAkS0Qnkn7BSVV3QvNdUrBM1ofXi33Y3V2XbJffFEM3nrJqESPdHWvwPOfdbg==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/autocomplete@2.3.23-beta.2':
+    resolution: {integrity: sha512-rofbrbcvFmH9UkdmfXXVcITeSezJ9DHDtkkBnHoadN6jR8bKK8ZurBgRFJ0fi7h1HsWtwAABS8+H5WE58vnkEg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/avatar@2.2.18-beta.2':
+    resolution: {integrity: sha512-KYUdjdblG1ZaunAacKnhGE5M5GV6IGhQHBEdMZB07foU+bv5eenDfKTeukOQtVTUZTsk6h35mAVQnzc9XERWVw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/badge@2.2.14-beta.2':
+    resolution: {integrity: sha512-gHh6MdhCQUHuLzS+K3aXpuw714KVY9alFtyLkW+E9rM3vOqYqWarsZLnbSL7VbHkbhOUsKSBDT9Fq0HH2cgIFQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/breadcrumbs@2.2.18-beta.2':
+    resolution: {integrity: sha512-Xl9g5/aLJQ/lCSXlpfUX1JQdIfvtcXynjlB+rdO8MIKx1HnPtTjf6fi4kgKzKy8Ru/lpv8784BM8iVcJfbbLCA==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/button@2.2.22-beta.2':
+    resolution: {integrity: sha512-4bbNN8BdcfMw+Bga7iuASxqsz0yD+aIT5GneuZBEGpegd3+1KnS3l00Ko/KEFVEqarA0aQtpfgAg4YPPowXuBg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/calendar@2.2.22-beta.2':
+    resolution: {integrity: sha512-PfVeHTofYv2Bih2pD9I/lt7sUv9bmeWnEJHN0yde2/T/1L096ZOXDSPk3G1RsGEwHkDbPsUJppmrfZ+qdIpGGw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/card@2.2.21-beta.2':
+    resolution: {integrity: sha512-FKONBih+g3u9ovMSa6r3oNk17Q5JuMlTKBi/Y4zj4eiyV+FI68tCGhI35vWKMKoWtMkWrCxTlIR1NrubLBK+Xw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/checkbox@2.3.21-beta.2':
+    resolution: {integrity: sha512-b3k+Hb4osfY9QR6O+1WqcXntIQGl1yfdWs7SldAQdn0O65A/eq5AotmkDjZ4izse1iD0asWwrKlT+9V/vfdZfQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/chip@2.2.18-beta.2':
+    resolution: {integrity: sha512-j5PAGMi/OFDr2ydSXfpxRvK+VAZMb/T5WU8nTmel1FLSYRYqkicYl4VXLhq2eW0abzbYuMt5pkZ1Idww9qc3sg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/code@2.2.17-beta.2':
+    resolution: {integrity: sha512-2Ggr1QgzHitjeqQrQCB6X4g+EmfNJcyyQ1FZaGNtrU7qWvIJSnL6qnQzSHEWzv6nx0sUpYnoVeAnN5hwbXNPLA==}
+    peerDependencies:
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/date-input@2.3.21-beta.2':
+    resolution: {integrity: sha512-4cnhGLTpk0yzAX9xHG4w2ipTSngzEl9skkXIDScqM9hOxCx4T9t5FS/sOQlMW18wCQ9Z+G10nUqKOWv0Mt3zGw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/date-picker@2.3.22-beta.2':
+    resolution: {integrity: sha512-FpyHHUcvPXlmKDSpWXqsE/5Seg3DfEh0ByEBzPBBvYtBsQ+XBg8PiZdRFbt2jYL4kLcjckkEh9QTNHAEAt06ig==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/divider@2.2.16-beta.2':
+    resolution: {integrity: sha512-BiJwg9Wth8rRDBWmVTKjOYW+nDWnYKqlsUqS59kuUs0pHOHHXUu800WOKasUI/dbYnVMCweYe+taLrikVRxxjA==}
+    peerDependencies:
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/dom-animation@2.1.10-beta.2':
+    resolution: {integrity: sha512-VWfPBhOsU77d+iYvWfMbdBB50FWJO4pAQiR6GrQ+ND8GoerZrJ5/c3o3HiyaiWGQRcM8LFxOiJzKaTLLD0lBog==}
+    peerDependencies:
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+
+  '@heroui/drawer@2.2.19-beta.2':
+    resolution: {integrity: sha512-hZXkeNjPcEW9g91zhdnVlUsgHF8sgfy98LO0vR80peXX7HWjEPs08jjMq2FIJRDq+5XEQBxMqURnU+VB1d0UCQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/dropdown@2.3.22-beta.2':
+    resolution: {integrity: sha512-EXbkOn7dc1ZAnf1ZkegWp+aMFQDHGKtNB90ouv+APAQ+Zude0newnKr4B2SMU/KzFVdwI0zqGOXKUD45MkFleg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/form@2.1.21-beta.2':
+    resolution: {integrity: sha512-5QLP6WrZsDVYqNA7duggxgYOCXvNfp3nMShbeq3ZQS7hwH/wmwCtoACasP3gbDHW+7xPNWZM8GT0jp0cGGCBvg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@heroui/framer-utils@2.1.18-beta.2':
+    resolution: {integrity: sha512-0GFmdfufRabLom3KvFxu8oKcjzuuLlMkWQNw7x/NBnDE/t5bf40gzVDbBvZA7etSDKxvq/98WTUYHEEmrEKO3w==}
+    peerDependencies:
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/image@2.2.14-beta.2':
+    resolution: {integrity: sha512-Tf7iHh9jjefT31YOJtM0wSZmbJ61KyOpDQaDMf1f7arpF1ApDNigkCpJSYWSTTzZ0B1Sd2Poci1a0Rcd7QYU7Q==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/input-otp@2.1.21-beta.2':
+    resolution: {integrity: sha512-XITk8VRErrbat9gweVIFsPbAmKZfDRDXnDJ8hq/fR2dQfvdApaykDKzlCL15p0vIFvp2o/+1ScGfiAxGV0ppyg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@heroui/input@2.4.22-beta.2':
+    resolution: {integrity: sha512-k4fo9zHIQuW9vnrQgBsuDczYkz4/g8i/Sn1NiWz1ybVe7F6rk/afsEildSh4I+nOxJ0fVRoWNJusL0kgBDwrbw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/kbd@2.2.18-beta.2':
+    resolution: {integrity: sha512-S3qhWJV6tkchg7pJr/Ou37eC+CyC7f2d6ZmgtHfZuoANHSR+MDZuAGekSlIgS2F9SLpUxDmyv0SPtjgjF/a8hQ==}
+    peerDependencies:
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/link@2.2.19-beta.2':
+    resolution: {integrity: sha512-/DeNq0EKpj1NyGD6RFJtz5WmxOQJV9WFXXge7Ito3OYgdJUf94ujMlF7p5YhXsVLkcZ4Zkeu/zHVSBTxa2TDNg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/listbox@2.3.21-beta.2':
+    resolution: {integrity: sha512-D9adixYFwTLzRco16YjHRWoymfpsUWu+el4hrIA+QJlld+V4fXt4aQ7XqReygbSgjaEhwcmC8gPnKNfTgd616g==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/menu@2.2.21-beta.2':
+    resolution: {integrity: sha512-8rjIh/5ZloRxpmswjsfXKikDsgknSTMFb/TvZwIVHOuR7TIPqNk2XN83m11EUFXd4YGf7ahjOD251VBFJC6gmg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/modal@2.2.19-beta.2':
+    resolution: {integrity: sha512-qAlmZFATOIwt6niotz8FQoDGWHexLcCpJi8OikESk48prVwUjMnUI4Pdizn6dS882nl1X9Q+A42j/9LO6182YA==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/navbar@2.2.20-beta.2':
+    resolution: {integrity: sha512-o7d3xDi1nIwXVD1ja1kICLrF/dY1usc6RtSWs3YHQJiELiB+t/hVUEZ1mv1L7wXa/n8JKqDY7ecdT7eq5Eg0Lw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/number-input@2.0.12-beta.2':
+    resolution: {integrity: sha512-2mIwtyy/+OtRDY3AxyUXPFvJALbfBZrY66bYCxaxAnVgjTTD3s85R7lbO7jj+kPq07xOmo7eEK6BVqgtQf+yzQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/pagination@2.2.20-beta.2':
+    resolution: {integrity: sha512-mKmOJhB6al/WwiDn8MkpDQfDfPP5ET1rODnm9XE7yuK79Y84wypgaBIMrgXg/GmCh7Jbi0kMCd2P/I5AeGH5vA==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/popover@2.3.22-beta.2':
+    resolution: {integrity: sha512-L+WwBczzyTEy7mIJQ2rXJt5kzFkVMeU4iuuPN0zvwUdPfA54OsSAJ6x+wcLp/jAYRqhikmlz58zGw4ZjI4pcXw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/progress@2.2.18-beta.2':
+    resolution: {integrity: sha512-aYOsn4d3j1RuRZHu3R/K3XQY/7LtmXUk61QDA17lchCsG/5q1sx3fJGXmTnwciMIZWk4gJx8IHuT7jq+QzM0dw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/radio@2.3.21-beta.2':
+    resolution: {integrity: sha512-n8FiFiUoMHNSReWSaOrhJ9r5gUd7nQLdlIVDF2aw2Ots/DHNbJzjNewPFqHZfvc0HZm0AABz9bM1bBANF3nsIg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/react-rsc-utils@2.1.9-beta.2':
+    resolution: {integrity: sha512-TuZGdd/EoZc3aM6Lbo5O6bbZf3yBhNrGknQyyMyqP84FFN0kIXdLhPl9j08Ua34vsLrbEx4wikzZx6jVPVAn8g==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/react-utils@2.1.12-beta.2':
+    resolution: {integrity: sha512-CYrtDVf3qH78ADSpLH1IUN8fpK9HgzWHzJi+SGeOxyt7VhiRbQycF4bErDYdZaJtTjZn9vsI3h1Mi+HUQHBn4w==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/react@2.8.0-beta.10':
+    resolution: {integrity: sha512-yGlAdxXYSMMzSsuRRKvB6fMxeeqjH1KPAgpqUFO2B7/uuZeVTEWKeA9PyDH4w9pDmsizULBz2nvpiZ7Uw4cEkA==}
+    peerDependencies:
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/ripple@2.2.17-beta.2':
+    resolution: {integrity: sha512-93sGhATmpQB1nNhv6rSwoFdZgTHzj1Q5Q0ef3R3+QMiF+KS4znVry3ieeJ8K5YVEfTmJmcSjbSAEODJkhU/E6w==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/scroll-shadow@2.3.15-beta.2':
+    resolution: {integrity: sha512-EkxfvwxqWYFa2DZpdfd9+SQr2IwrgGHKX1IXF5YUtqoXHM71xZtIKyvUfs/HgCvkVkcrXUOMVbrFcUYJ8W73yQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/select@2.4.22-beta.2':
+    resolution: {integrity: sha512-aGrZg9TY6RzGH9w1ubT7UGGGSdCFG0eY72YYLqbigAAWZVwOqhjViU+Miowu/sc5/Wc6o2LHeZfS2MGmh8qSTw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/shared-icons@2.1.10-beta.2':
+    resolution: {integrity: sha512-vburW3cLQqIarx4QK8iInl7aqFJTc5nCRxok+ywkjqBzbj/xeUXKJHbF7R8PyI8r3urGs3qIofi2mYk83eJVXw==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/shared-utils@2.1.10-beta.4':
+    resolution: {integrity: sha512-KlP/qfIS0gzLUdCkIs8/JNt1qtEDnTgqyaTOp6159pjKowJxlqOjmLVxGCK1Y9Fk+noNnJ+9UtD5pShPQNbKDw==}
+
+  '@heroui/skeleton@2.2.14-beta.2':
+    resolution: {integrity: sha512-rSD5Dlv0agvl2UKanik+iake0vzZV9U+vEqwewG9nzMjtN0BNUZBkxluFQuezWIrAQYUp+0Qh72uKNLy+Rx63w==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/slider@2.4.19-beta.2':
+    resolution: {integrity: sha512-V6mBDS43VvEjx91FBxMjmIvS+IpO+42enkuKJno7s7xcsOfbf/gm3+JDLh0em485Ge5OcPHpHAwcLj97B77dyw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/snippet@2.2.23-beta.2':
+    resolution: {integrity: sha512-RTcRFGvhixVMr/cs4jrWPkjgBTVYfqQ3LSOI4c+XGoATkHMXLPCNOP1u2skSadXDqWPoMdHp9RdItqB+xLRMZQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/spacer@2.2.17-beta.2':
+    resolution: {integrity: sha512-xA3Lgl8yitp1eptl82jOx87p/yA19De4BYXJAy+yUwOrSYwVKmS/7tx7kCMo6n+cebRLVcb7zwiHeR9PAsbNIg==}
+    peerDependencies:
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/spinner@2.2.19-beta.2':
+    resolution: {integrity: sha512-wJ0WfiESWdQBPAz1ONMn+Z3GvzCFSgDRyki+TDPjSQjL811A8CBJ/Wx+WfuuweFy1v3IvNzNh536dClZlxJ4nw==}
+    peerDependencies:
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/switch@2.2.20-beta.2':
+    resolution: {integrity: sha512-g2x9tFtBMZHcR3NI3mEiG2gf6n2PO/l5+7EHOpgtcXKKWIIxiUiebra443Kygn1BxSNetg0dPWGT4yXSqJL+Qg==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/system-rsc@2.3.16-beta.2':
+    resolution: {integrity: sha512-vTYwQK2w4lSCaveBgp2XNki/Qk4qi4TgxW99GXcQVFNiqHbnpAYulU1RqLZgtdk1p0o5G7In6mhJjax2s4h7qQ==}
+    peerDependencies:
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/system@2.4.18-beta.2':
+    resolution: {integrity: sha512-PKF0bHrx4CBhJ20qCVNfxuc3dfQInFBCSvK5ibLb+62CTB1npwcwcJ0nsnJJv0PHGd+6e8BMpUJlNN/lRiERDg==}
+    peerDependencies:
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/table@2.2.21-beta.2':
+    resolution: {integrity: sha512-Sqim7VxBTA0rI09QLnt4Li63TYbEWceaLQfoBxWWoFDWtivuAv+WCYj+baExGckl+ag1pOQhFg0jv1DTwWvkZQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/tabs@2.2.19-beta.2':
+    resolution: {integrity: sha512-I/ZG/VfBkDt+c6H5FEVn4N8GGJc+ExTVZZhtYBfePwVjc0aCH3YpZ8toVvrinN6wof7kWx2D929/zMdI9J0yoQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/theme@2.4.18-beta.2':
+    resolution: {integrity: sha512-gMAsElhNF4z8ZPl6dEea3yg55UcYAh4gmtAP9FhO3h1uhzw84T99lFkVoO7yloTalj+xNEoIlyfBb35N8DC5pA==}
+    peerDependencies:
+      tailwindcss: '>=4.0.0'
+
+  '@heroui/toast@2.0.12-beta.2':
+    resolution: {integrity: sha512-ZeaGAYv0QhpMG9WIikeHiA+0z2R4VOYgzBGCDqn5J5AzfdH7BPYJaldZk8zUV92TrA8f8NEuxeuw4vHg1yfCPw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/tooltip@2.2.19-beta.2':
+    resolution: {integrity: sha512-VJUh/6IXU8hN3LOSnbw2fwxcyw3VBXqavCgXvZJZ66NrQTpBJn25pcLMbY4X80nleJX6kbfD62sz8UUMLPCbFw==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-aria-accordion@2.2.14-beta.2':
+    resolution: {integrity: sha512-JgxqhYfk+MLr3MTAb/qAiTz3cXTG2ikrCyWAwZTkXqHUjbtOeFV2fJI46rIFiZ61IMYn7t0nkTlQ/PZKiNfOng==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-aria-button@2.2.16-beta.2':
+    resolution: {integrity: sha512-FlCuZF7DQAnfNtxulu3aY07/4FbWIJL/ZX/iw95rk4g7DUNnLbYPnYlThEg9cExfvk1k+VUL2mm+lw9iJ+8H3w==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-aria-link@2.2.17-beta.2':
+    resolution: {integrity: sha512-4MvN0H8aYGyE6RKF9X+uWxgOTCEg2gEaY7Sk7N61jfT8xLQzHkKgg8WoOk6F4/NiFKEoILi68UxD8+fa7y+INA==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-aria-modal-overlay@2.2.15-beta.2':
+    resolution: {integrity: sha512-795MgzX1QsIZEoxLACnyvb3RBOmOovRfc3agpHmXL3OXY9y8wJK/iW9l0Ls41YF9fKJ4kSMX//VvLsz6hjfNug==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-aria-multiselect@2.4.15-beta.2':
+    resolution: {integrity: sha512-d2RJepptG1LFRP1hden/Sv6IoJ74IH9yTkWcGZIlAfr5YE+AcT61EklLLqlLlIb+lRmuN4myj/ylSg5hceOJDw==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-aria-overlay@2.0.1-beta.4':
+    resolution: {integrity: sha512-hcXJG4jD5U7wUoZW5rkGQfexvC1DAd1kDrAu3Osz+XPbpPW2nVKDUioZaylpnJILKfmw4NC1hNIWXWfaLj62Cw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@heroui/use-callback-ref@2.1.8-beta.4':
+    resolution: {integrity: sha512-Elf7h9rM1oaptUorxvTi5a68k84BeA9DisRgbUF6Lnw9za4p2VQQ5KQ/uDb/I6h7i0kKwXTGg5HmKHtdev0V4A==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-clipboard@2.1.9-beta.4':
+    resolution: {integrity: sha512-mUgILqZtOm9kpcFFCgXoRQ3imv7e3nmcyWkd09xE1K7/gURuFXnMK77sHnS9qV6A2gnE5DwAOQGtlVRfGjOhNw==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-data-scroll-overflow@2.2.11-beta.4':
+    resolution: {integrity: sha512-lqeBXDsp1lrXkkyuvUtgEIsUtuWN05zzRcb5fyX9sE4OTr+sWAHpoaoia3QPqhu4PtnSZ3radK8rHvGlfvI6wA==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-disclosure@2.2.14-beta.2':
+    resolution: {integrity: sha512-B4cPqSv+nhuFmdKXfOYxaTKsfu23KvnRDhBEKIckwKQTPFgjgHswMA8Yd+jQm4PKbByW4Wkikc3eguHeQu6ncg==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-draggable@2.1.14-beta.2':
+    resolution: {integrity: sha512-7f3iwu51pxGrAnApBjOh/u6nOWsG3zEI2hbruNntP0K4zVFI5SX7HtF+AwelvQTUNEkga6Sr7BVtH10tYh57JA==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-form-reset@2.0.0-beta.1':
+    resolution: {integrity: sha512-Di8809HG7ZTqJ+92MHlNgNT9n7VMWd0nT3Nq4lzlRv+l7Ku6U+doYGxKKej3wpdoEVrxKzH2juhj6SF1yUNWQQ==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-image@2.1.11-beta.2':
+    resolution: {integrity: sha512-zuBVsjU0VRkelIBC9BIYgoHKXyxgwTtZ+vtnL6RjmvBm9m7RDDJM5A2b5xyl9m78KF3T0ylIVScWiBTJzKqR1w==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-intersection-observer@2.2.14-beta.2':
+    resolution: {integrity: sha512-ZBqws//A0xYHC55v0LfsB21Svt7qi+uSgHdRPKD6yzl8fvE6vFy93FauHDAesREpSmK017y4Dsd60vxcr6thrg==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-is-mobile@2.2.11-beta.2':
+    resolution: {integrity: sha512-SY3DrkCIPM+mlYDDm+v/mummL8maP0EG9vvZtP/c6n7qIImshjRd/4Ik1KHtlYuxKO1xGqKm5N8Fmdy8IVLNYw==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-is-mounted@2.1.8-beta.4':
+    resolution: {integrity: sha512-cx4axqJ1Fe0nQ7AkjWmJW7m+uwahLbbZDnMaeNf98uN822tAosDxuPRwdYlJJoul2W9vfdLG9tc1By6qoAETqg==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-measure@2.1.8-beta.4':
+    resolution: {integrity: sha512-joX8KNgOJ+dicYMWMagHYXdJyTxWSfTMzmsxMZx5Byx0SwfEqJb4xPDpU7oRNOkc1+2AcFPGTyxFQ+KCJGB5WA==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-pagination@2.2.15-beta.2':
+    resolution: {integrity: sha512-kaP7JQi2Cno/AM3yavMtD0X87LYtNpica29PRRYBUSjf/Y6ncULP/fXX+wFUz90kvn3zcuIX1xHeOuoQMLE9fA==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-resize@2.1.8-beta.4':
+    resolution: {integrity: sha512-KHDK00TWS2qmRlgUawJGK0Rqcb+LV5FOfFnYkbCbNjrLCauURGcN5PJmvkUhixagw9EOdpWZmTP/dvdQ9XmvAw==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-safe-layout-effect@2.1.8-beta.4':
+    resolution: {integrity: sha512-B5plzjiecWz4Cd+HRwAH9NbuFS5258HCy3yKMsSeKqNmbH/zyXIQYZ+Yc/d8suSS+XvcWibxnAWLIa5pyHDHLw==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-scroll-position@2.1.8-beta.4':
+    resolution: {integrity: sha512-Nsg8azfcUoOGpBx8UYRI3AGCJtGcXB82XRk+IDwxuhlgI3HLUR0a1l8C639v9VxZYqgs3lDtmrLPh9DdBaMcjQ==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/use-viewport-size@2.0.0-beta.1':
+    resolution: {integrity: sha512-uq/YnQ6DCagynmLycPM2nGzhJF2cUsUF5Yzic+o/WqKjBXNAyWChYGlkl2S1XGc9dN/uETi2O2Rfp6SZQK9tcQ==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+
+  '@heroui/user@2.2.18-beta.2':
+    resolution: {integrity: sha512-4W9ToE+N+zKiC4iP6i4AOWCjcDE7+nsg5FyL5ETtD368LNsXfaBZ8UD8OqvNxtZbA8QxdWOAjfVy7g6GwSdFkQ==}
+    peerDependencies:
+      '@heroui/system': '>=2.4.18-beta.0'
+      '@heroui/theme': '>=2.4.18-beta.0'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
+
+  '@internationalized/date@3.8.2':
+    resolution: {integrity: sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==}
+
+  '@internationalized/message@3.1.8':
+    resolution: {integrity: sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==}
+
+  '@internationalized/number@3.6.3':
+    resolution: {integrity: sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==}
+
+  '@internationalized/string@3.2.7':
+    resolution: {integrity: sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -293,6 +880,463 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@react-aria/breadcrumbs@3.5.26':
+    resolution: {integrity: sha512-jybk2jy3m9KNmTpzJu87C0nkcMcGbZIyotgK1s8st8aUE2aJlxPZrvGuJTO8GUFZn9TKnCg3JjBC8qS9sizKQg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/button@3.13.3':
+    resolution: {integrity: sha512-Xn7eTssaefNPUydogI1qDf7qQWPmb+hGoS1QiCNBodPlRpVDXxlZSIhOqQFnLWHv5+z5UL+vu+joqlSPYHqOFw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/calendar@3.8.3':
+    resolution: {integrity: sha512-1TAZADcWbfznXzo4oJEqFgX4IE1chZjWsTSJDWr03UEx3XqIJI8GXm+ylOQUiN4j8xqZ7tl4yNuuslKkzoSjMQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/checkbox@3.15.7':
+    resolution: {integrity: sha512-L64van+K2ZEmCpx/KeZGHoxdxQvVHgfusFRFYZbh3e7YEtDcShvUrTDVKmZkINqnmuhGTDolFDQq+E8fWEpcRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/combobox@3.12.5':
+    resolution: {integrity: sha512-mg9RrOTjxQFPy0BQrlqdp5uUC2pLevIqhZit6OfndmOr7khQ32qepDjXoSwYeeSag/jrokc2cGfXfzOwrgAFaQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/datepicker@3.14.5':
+    resolution: {integrity: sha512-TeV/yXEOQ2QOYMxvetWcWUcZN83evmnmG/uSruTdk93e2nZzs227Gg/M95tzgCYRRACCzSzrGujJhNs12Nh7mg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/dialog@3.5.27':
+    resolution: {integrity: sha512-Sp8LWQQYNxkLk2+L0bdWmAd9fz1YIrzvxbHXmAn9Tn6+/4SPnQhkOo+qQwtHFbjqe9fyS7cJZxegXd1RegIFew==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/focus@3.20.5':
+    resolution: {integrity: sha512-JpFtXmWQ0Oca7FcvkqgjSyo6xEP7v3oQOLUId6o0xTvm4AD5W0mU2r3lYrbhsJ+XxdUUX4AVR5473sZZ85kU4A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/form@3.0.18':
+    resolution: {integrity: sha512-e4Ktc3NiNwV5dz82zVE7lspYmKwAnGoJfOHgc9MApS7Fy/BEAuVUuLgTjMo1x5me7dY+ADxqrIhbOpifscGGoQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/grid@3.14.2':
+    resolution: {integrity: sha512-5oS6sLq0DishBvPVsWnxGcUdBRXyFXCj8/n02yJvjbID5Mpjn9JIHUSL4ZCZAO7QGCXpvO3PI40vB2F6QUs2VA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/i18n@3.12.10':
+    resolution: {integrity: sha512-1j00soQ2W0nTgzaaIsGFdMF/5aN60AEdCJPhmXGZiuWdWzMxObN9LQ9vdzYPTjTqyqMdSaSp9DZKs5I26Xovpw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/interactions@3.25.3':
+    resolution: {integrity: sha512-J1bhlrNtjPS/fe5uJQ+0c7/jiXniwa4RQlP+Emjfc/iuqpW2RhbF9ou5vROcLzWIyaW8tVMZ468J68rAs/aZ5A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/label@3.7.19':
+    resolution: {integrity: sha512-ZJIj/BKf66q52idy24ErzX77vDGuyQn4neWtu51RRSk4npI3pJqEPsdkPCdo2dlBCo/Uc1pfuLGg2hY3N/ni9Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/landmark@3.0.4':
+    resolution: {integrity: sha512-1U5ce6cqg1qGbK4M4R6vwrhUrKXuUzReZwHaTrXxEY22IMxKDXIZL8G7pFpcKix2XKqjLZWf+g8ngGuNhtQ2QQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/link@3.8.3':
+    resolution: {integrity: sha512-83gS9Bb+FMa4Tae2VQrOxWixqYhqj4MDt4Bn0i3gzsP/sPWr1bwo5DJmXfw16UAXMaccl1rUKSqqHdigqaealw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/listbox@3.14.6':
+    resolution: {integrity: sha512-ZaYpBXiS+nUzxAmeCmXyvDcZECuZi1ZLn5y8uJ4ZFRVqSxqplVHodsQKwKqklmAM3+IVDyQx2WB4/HIKTGg2Bw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/live-announcer@3.4.3':
+    resolution: {integrity: sha512-nbBmx30tW53Vlbq3BbMxHGbHa7vGE9ItacI+1XAdH2UZDLtdZA5J6U9YC6lokKQCv+aEVO6Zl9YG4yp57YwnGw==}
+
+  '@react-aria/menu@3.18.5':
+    resolution: {integrity: sha512-mOQb4PcNvDdFhyqF7nxREwc1YUg+pPTiMNcSHlz/MKFkkUteIQBYfuJJa8i72ooiE55xfYEQhPLjmrLHAOIJ+g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/numberfield@3.11.16':
+    resolution: {integrity: sha512-AGk0BMdHXPP3gSy39UVropyvpNMxAElPGIcicjXXyD/tZdemsgLXUFT2zI4DwE0csFZS8BGgunLWT9VluMF4FQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/overlays@3.27.3':
+    resolution: {integrity: sha512-1hawsRI+QiM0TkPNwApNJ2+N49NQTP+48xq0JG8hdEUPChQLDoJ39cvT1sxdg0mnLDzLaAYkZrgfokq9sX6FLA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/progress@3.4.24':
+    resolution: {integrity: sha512-lpMVrZlSo1Dulo67COCNrcRkJ+lRrC2PI3iRoOIlqw1Ljz4KFoSGyRudg/MLJ/YrQ+6zmNdz5ytdeThrZwHpPQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/radio@3.11.5':
+    resolution: {integrity: sha512-6BjpeTupQnxetfvC2bqIxWUt6USMqNZoKOoOO7mUL7ESF6/Gp8ocutvQn0VnTxU+7OhdrZX5AACPg/qIQYumVw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/selection@3.24.3':
+    resolution: {integrity: sha512-QznlHCUcjFgVALUIVBK4SWJd6osaU9lVaZgU4M8uemoIfOHqnBY3zThkQvEhcw/EJ2RpuYYLPOBYZBnk1knD5A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/slider@3.7.21':
+    resolution: {integrity: sha512-eWu69KnQ7qCmpYBEkgGLjIuKfFqoHu2W6r9d7ys0ZmX81HPj9DhatGpEgHlnjRfCeSl9wL5h2FY9wnIio82cbg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/spinbutton@3.6.16':
+    resolution: {integrity: sha512-Ko1e9GeQiiEXeR3IyPT8STS1Pw4k/1OBs9LqI3WKlHFwH5M8q3DbbaMOgekD41/CPVBKmCcqFM7K7Wu9kFrT2A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/ssr@3.9.9':
+    resolution: {integrity: sha512-2P5thfjfPy/np18e5wD4WPt8ydNXhij1jwA8oehxZTFqlgVMGXzcWKxTb4RtJrLFsqPO7RUQTiY8QJk0M4Vy2g==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/switch@3.7.5':
+    resolution: {integrity: sha512-GV9rFYf4wRHAh9tkhptvm3uOflKcQHdgZh+eGpSAHyq2iTq0j2nEhlmtFordpcJgC4XWro7TXLNltfqUqVHtkw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/table@3.17.5':
+    resolution: {integrity: sha512-Q9HDr2EAhoah7HFIT6XxOOOv2fiAs0agwQQd3d1w6jqgyu9m20lM/jxcSwcCFj2O7FPKHfapSAijHDZZoc4Shg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/tabs@3.10.5':
+    resolution: {integrity: sha512-ddmGPikXW+27W2Rx0VuEwwGJVLTo68QkNbSl8R+TEM0EUIAJo3nwHzAlQhuo5Tcb1PdK7biTjO1dyI4pno2/0Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/textfield@3.17.5':
+    resolution: {integrity: sha512-HFdvqd3Mdp6WP7uYAWD64gRrL1D4Khi+Fm3dIHBhm1ANV0QjYkphJm4DYNDq/MXCZF46+CZNiOWEbL/aeviykA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/toast@3.0.5':
+    resolution: {integrity: sha512-uhwiZqPy6hqucBUL7z6uUZjAJ/ou3bNdTjZlXS+zbcm+T0dsjKDfzNkaebyZY7AX3cYkFCaRjc3N6omXwoAviw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/toggle@3.11.5':
+    resolution: {integrity: sha512-8+Evk/JVMQ25PNhbnHUvsAK99DAjnCWMdSBNswJ1sWseKCYQzBXsNkkF6Dl/FlSkfDBFAaRHkX9JUz02wehb9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/toolbar@3.0.0-beta.18':
+    resolution: {integrity: sha512-P1fXhmTRBK4YvPQDzCY3XoZl+HiBADgvQ89jszxJ2jD4Qzs/E096ttCc+otZnbvRcoU27IxC2vWFInqK/bP31g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/tooltip@3.8.5':
+    resolution: {integrity: sha512-spGAuHHNkiqAfyOl4JWzKEK642KC1oQylioYg+LKCq2avUyaDqFlRx2JrC4a6nt3BV6E5/cJUMV9K7gMRApd5Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/utils@3.29.1':
+    resolution: {integrity: sha512-yXMFVJ73rbQ/yYE/49n5Uidjw7kh192WNN9PNQGV0Xoc7EJUlSOxqhnpHmYTyO0EotJ8fdM1fMH8durHjUSI8g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/visually-hidden@3.8.25':
+    resolution: {integrity: sha512-9tRRFV1YMLuDId9E8PeUf0xy0KmQBoP8y/bm0PKWzXOqLOVmp/+kop9rwsjC7J6ppbBnlak7XCXTc7GoSFOCRA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/calendar@3.8.2':
+    resolution: {integrity: sha512-IGSbTgCMiGYisQ+CwH31wek10UWvNZ1LVwhr0ZNkhDIRtj+p+FuLNtBnmT1CxTFe2Y4empAxyxNA0QSjQrOtvQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/checkbox@3.6.15':
+    resolution: {integrity: sha512-jt3Kzbk6heUMtAlCbUwnrEBknnzFhPBFMEZ00vff7VyhDXup7DJcJRxreloHepARZLIhLhC5QPyO5GS4YOHlvw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/collections@3.12.5':
+    resolution: {integrity: sha512-5SIb+6nF9cyu+WXqZ6io56BtdOu8FjSQQaaLCCpfAC6fc6zHRk8by0WreRmvJ5/Kn8oq2FNJtCNRvluM0Z01UA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/combobox@3.10.6':
+    resolution: {integrity: sha512-XOfG90MQPfPCNjl2KJOKuFFzx2ULlwnJ/QXl9zCQUtUBOExbFRHldj5E4NPcH14AVeYZX6DBn4GTS9ocOVbE7Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/datepicker@3.14.2':
+    resolution: {integrity: sha512-KvOUFz/o+hNIb7oCli6nxBdDurbGjRjye6U99GEYAx6timXOjiIJvtKQyqCLRowGYtCS6GH41yM6DhJ2MlMF8w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/flags@3.1.2':
+    resolution: {integrity: sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==}
+
+  '@react-stately/form@3.1.5':
+    resolution: {integrity: sha512-wOs0SVXFgNr1aIdywiNH1MhxrFlN5YxBr1k9y3Z7lX+pc/MGRJFTgfDDw5JDxvwLH9joJ9ciniCdWep9L/TqcQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/grid@3.11.3':
+    resolution: {integrity: sha512-/YurYfPARtgsgS5f8rklB7ZQu6MWLdpfTHuwOELEUZ4L52S2gGA5VfLxDnAsHHnu5XHFI3ScuYLAvjWN0rgs/Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/list@3.12.3':
+    resolution: {integrity: sha512-RiqYyxPYAF3YRBEin8/WHC8/hvpZ/fG1Tx3h1W4aXU5zTIBuy0DrjRKePwP90oCiDpztgRXePLlzhgWeKvJEow==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/menu@3.9.5':
+    resolution: {integrity: sha512-Y+PqHBaQToo6ooCB4i4RoNfRiHbd4iozmLWePBrF4d/zBzJ9p+/5O6XIWFxLw4O128Tg3tSMGuwrxfecPDYHzA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/numberfield@3.9.13':
+    resolution: {integrity: sha512-FWbbL4E3+5uctPGVtDwHzeNXgyFw0D3glOJhgW1QHPn3qIswusn0z/NjFSuCVOSpri8BZYIrTPUQHpRJPnjgRw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/overlays@3.6.17':
+    resolution: {integrity: sha512-bkGYU4NPC/LgX9OGHLG8hpf9QDoazlb6fKfD+b5o7GtOdctBqCR287T/IBOQyvHqpySqrQ8XlyaGxJPGIcCiZw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/radio@3.10.14':
+    resolution: {integrity: sha512-Y7xizUWJ0YJ8pEtqMeKOibX21B5dk56fHgMHXYLeUEm43y5muWQft2YvP0/n4mlkP2Isbk96kPbv7/ez3Gi+lA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/select@3.6.14':
+    resolution: {integrity: sha512-HvbL9iMGwbev0FR6PzivhjKEcXADgcJC/IzUkLqPfg4KKMuYhM/XvbJjWXn/QpD3/XT+A5+r5ExUHu7wiDP93w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/selection@3.20.3':
+    resolution: {integrity: sha512-TLyjodgFHn5fynQnRmZ5YX1HRY0KC7XBW0Nf2+q9mWk4gUxYm7RVXyYZvMIG1iKqinPYtySPRHdNzyXq9P9sxQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/slider@3.6.5':
+    resolution: {integrity: sha512-XnHSHbXeHiE5J7nsXQvlXaKaNn1Z4jO1aQyiZsolK1NXW6VMKVeAgZUBG45k7xQW06aRbjREMmiIz02mW8fajQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/table@3.14.3':
+    resolution: {integrity: sha512-PwE5pCplLSDckvgmNLVaHyQyX04A62kxdouFh1dVHeGEPfOYsO9WhvyisLxbH7X8Dbveheq/tSTelYDi6LXEJA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/tabs@3.8.3':
+    resolution: {integrity: sha512-FujQCHppXyeHs2v5FESekxodsBJ5T0k1f7sm0ViNYqgrnE5XwqX8Y4/tdr0fqGF6S+BBllH+Q9yKWipDc6OM8g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/toast@3.1.1':
+    resolution: {integrity: sha512-W4a6xcsFt/E+aHmR2eZK+/p7Y5rdyXSCQ5gKSnbck+S3lijEWAyV45Mv8v95CQqu0bQijj6sy2Js1szq10HVwg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/toggle@3.8.5':
+    resolution: {integrity: sha512-BSvuTDVFzIKxpNg9Slf+RdGpva7kBO8xYaec2TW9m6Ag9AOmiDwUzzDAO0DRsc7ArSaLLFaQ/pdmmT6TxAUQIA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/tooltip@3.5.5':
+    resolution: {integrity: sha512-/zbl7YxneGDGGzdMPSEYUKsnVRGgvsr80ZjQYBHL82N4tzvtkRwmzvzN9ipAtza+0jmeftt3N+YSyxvizVbeKA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/tree@3.9.0':
+    resolution: {integrity: sha512-VpWAh36tbMHJ1CtglPQ81KPdpCfqFz9yAC6nQuL1x6Tmbs9vNEKloGILMI9/4qLzC+3nhCVJj6hN+xqS5/cMTg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/utils@3.10.7':
+    resolution: {integrity: sha512-cWvjGAocvy4abO9zbr6PW6taHgF24Mwy/LbQ4TC4Aq3tKdKDntxyD+sh7AkSRfJRT2ccMVaHVv2+FfHThd3PKQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/virtualizer@4.4.1':
+    resolution: {integrity: sha512-ZjhsmsNqKY4HrTuT9ySh8lNmYHGgFX24CVVQ3hMr8dTzO9DRR89BMrmenoVtMj7NkonWF8lUFyYlVlsijs2p4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/accordion@3.0.0-alpha.26':
+    resolution: {integrity: sha512-OXf/kXcD2vFlEnkcZy/GG+a/1xO9BN7Uh3/5/Ceuj9z2E/WwD55YwU3GFM5zzkZ4+DMkdowHnZX37XnmbyD3Mg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/breadcrumbs@3.7.14':
+    resolution: {integrity: sha512-SbLjrKKupzCLbqHZIQYtQvtsXN53NPxOYyug6QfC4d7DcW1Q9wJ546fxb10Y83ftAJMMUHTatI6SenJVoqyUdA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/button@3.12.2':
+    resolution: {integrity: sha512-QLoSCX8E7NFIdkVMa65TPieve0rKeltfcIxiMtrphjfNn+83L0IHMcbhjf4r4W19c/zqGbw3E53Hx8mNukoTUw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/calendar@3.7.2':
+    resolution: {integrity: sha512-Bp6fZo52fZdUjYbtJXcaLQ0jWEOeSoyZVwNyN5G6BmPyLP5nHxMPF+R1MPFR0fdpSI4/Sk78gWzoTuU5eOVQLw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/checkbox@3.9.5':
+    resolution: {integrity: sha512-9y8zeGWT2xZ38/YC/rNd05pPV8W8vmqFygCpZFaa6dJeOsMgPU+rq+Ifh1G+34D/qGoZXQBzeCSCAKSNPaL7uw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/combobox@3.13.6':
+    resolution: {integrity: sha512-BOvlyoVtmQJLYtNt4w6RvRORqK4eawW48CcQIR93BU5YFcAGhpcvpjhTZXknSXumabpo1/XQKX4NOuXpfUZrAQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/datepicker@3.12.2':
+    resolution: {integrity: sha512-w3JIXZLLZ15zjrAjlnflmCXkNDmIelcaChhmslTVWCf0lUpgu1cUC4WAaS71rOgU03SCcrtQ0K9TsYfhnhhL7Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/dialog@3.5.19':
+    resolution: {integrity: sha512-+FIyFnoKIGNL20zG8Sye7rrRxmt5HoeaCaHhDCTtNtv8CZEhm3Z+kNd4gylgWAxZRhDtBRWko+ADqfN5gQrgKg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/form@3.7.13':
+    resolution: {integrity: sha512-Ryw9QDLpHi0xsNe+eucgpADeaRSmsd7+SBsL15soEXJ50K/EoPtQOkm6fE4lhfqAX8or12UF9FBcBLULmfCVNQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/grid@3.3.3':
+    resolution: {integrity: sha512-VZAKO3XISc/3+a+DZ+hUx2NB/buOe2Ui2nISutv25foeXX4+YpWj5lXS74lJUCuVsSz6D6yoWvEajeUCYrNOxg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/link@3.6.2':
+    resolution: {integrity: sha512-CtCexoupcaFHJdVPRUpJ83uxK1U0bd9x9DhwRFMqqfPHufICkQkETIw2KIeZXRvMUMi2CSG/81XXy6K0K1MtNw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/listbox@3.7.1':
+    resolution: {integrity: sha512-WiCihJJpVWVEUxxZjhTbnG3Zq3q38XylKnvNelkVHbF+Y3+SXWN0Yyhk43J642G/d87lw1t60Tor0k96eaz4vw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/menu@3.10.2':
+    resolution: {integrity: sha512-TVQFGttaNCcIvy1MKavb9ZihJmng46uUtVF9oTG/VI/C4YEdzekteI6iSsXbjv5ZAvOKQR+S25IWCbK2W0YCjQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/numberfield@3.8.12':
+    resolution: {integrity: sha512-cI0Grj+iW5840gV80t7aXt7FZPbxMZufjuAop5taHe6RlHuLuODfz5n3kyu/NPHabruF26mVEu0BfIrwZyy+VQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/overlays@3.8.16':
+    resolution: {integrity: sha512-Aj9jIFwALk9LiOV/s3rVie+vr5qWfaJp/6aGOuc2StSNDTHvj1urSAr3T0bT8wDlkrqnlS4JjEGE40ypfOkbAA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/progress@3.5.13':
+    resolution: {integrity: sha512-+4v++AP2xxYxjrTkIXlWWGUhPPIEBzyg76EW0SHKnD4pXxKigcIXEzRbxy62SMidTVdi7jh3tuicIP8OQxJ4cA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/radio@3.8.10':
+    resolution: {integrity: sha512-hLOu2CXxzxQqkEkXSM71jEJMnU5HvSzwQ+DbJISDjgfgAKvZZHMQX94Fht2Vj+402OdI77esl3pJ1tlSLyV5VQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/select@3.9.13':
+    resolution: {integrity: sha512-R7zwck353RV60gZimZ8pDKaj50aEtGzU8gk0jC3aBkfzSUKFJ6jq1DJdqyVQSwXdmPDd9iuketeIUIpEO2teoA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.30.0':
+    resolution: {integrity: sha512-COIazDAx1ncDg046cTJ8SFYsX8aS3lB/08LDnbkH/SkdYrFPWDlXMrO/sUam8j1WWM+PJ+4d1mj7tODIKNiFog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/slider@3.7.12':
+    resolution: {integrity: sha512-kOQLrENLpQzmu6TfavdW1yfEc8VPitT4ZNMKOK0h7x3LskEWjptxcZ4IBowEpqHwk0eMbI9lRE/3tsShGUoLwQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/switch@3.5.12':
+    resolution: {integrity: sha512-6Zz7i+L9k8zw2c3nO8XErxuIy7JVDptz1NTZMiUeyDtLmQnvEKnKPKNjo2j+C/OngtJqAPowC3xRvMXbSAcYqA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/table@3.13.1':
+    resolution: {integrity: sha512-fLPRXrZoplAGMjqxHVLMt7lB0qsiu1WHZmhKtroCEhTYwnLQKL84XFH4GV1sQgQ1GIShl3BUqWzrawU5tEaQkw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/tabs@3.3.16':
+    resolution: {integrity: sha512-z6AWq243EahGuT4PhIpJXZbFez6XhFWb4KwhSB2CqzHkG5bJJSgKYzIcNuBCLDxO7Qg25I+VpFJxGj+aqKFbzQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/textfield@3.12.3':
+    resolution: {integrity: sha512-72tt2GJSyVFPPqZLrlfWqVn5KRnWzXsXCZ3IDawcGunl4pu+2E24jd0CWN9kOi0ETO65flj2sljeytxKytXnlA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/tooltip@3.4.18':
+    resolution: {integrity: sha512-/eG8hiW0D4vaCqGDa4ttb+Jnbiz6nUr5+f+LRgz3AnIkdjS9eOhpn6vXMX4hkNgcN5FGfA4Uu1C1QdM6W97Kfw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@rolldown/pluginutils@1.0.0-beta.19':
     resolution: {integrity: sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==}
@@ -397,6 +1441,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@swc/helpers@0.5.17':
+    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
   '@tailwindcss/node@4.1.11':
     resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
 
@@ -487,6 +1534,15 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tanstack/react-virtual@3.11.3':
+    resolution: {integrity: sha512-vCU+OTylXN3hdC8RKg68tPlBPjjxtzon7Ys46MgrSLE+JhSjSTPvoQifV6DQJeJmA8Q3KT6CphJbejupx85vFw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.11.3':
+    resolution: {integrity: sha512-v2mrNSnMwnPJtcVqNvV0c5roGCBqeogN8jDtgtuHCphdwBasOZ17x8UV8qpHUh+u0MLfX43c0uUHKje0s+Zb0w==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -546,6 +1602,14 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -553,9 +1617,22 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color2k@2.0.3:
+    resolution: {integrity: sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  compute-scroll-into-view@3.1.1:
+    resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
   concurrently@9.2.0:
     resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
@@ -573,6 +1650,13 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -629,6 +1713,10 @@ packages:
       picomatch:
         optional: true
 
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
@@ -641,6 +1729,20 @@ packages:
   form-data@4.0.3:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
     engines: {node: '>= 6'}
+
+  framer-motion@12.19.2:
+    resolution: {integrity: sha512-0cWMLkYr+i0emeXC4hkLF+5aYpzo32nRdQ0D/5DI460B3O7biQ3l2BpDzIGsAHYuZ0fpBP0DC8XBkVf6RPAlZw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -692,6 +1794,18 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  input-otp@1.4.1:
+    resolution: {integrity: sha512-+yvpmKYKHi9jIGngxagY9oWiiblPB7+nEO75F2l2o4vs+6vpPZZmUl4tBNYuTCvQjhvEIbdNeJu70bhfYP2nbw==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
+  intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
+
+  is-arrayish@0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -823,6 +1937,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  motion-dom@12.19.0:
+    resolution: {integrity: sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==}
+
+  motion-utils@12.19.0:
+    resolution: {integrity: sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -861,6 +1981,12 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -880,6 +2006,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  scroll-into-view-if-needed@3.0.10:
+    resolution: {integrity: sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -887,6 +2016,9 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  simple-swizzle@0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -907,6 +2039,15 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  tailwind-merge@3.0.2:
+    resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
+
+  tailwind-variants@1.0.0:
+    resolution: {integrity: sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwindcss: '*'
 
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
@@ -935,6 +2076,38 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-plugin-full-reload@1.2.0:
     resolution: {integrity: sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==}
@@ -1096,6 +2269,8 @@ snapshots:
       '@babel/core': 7.27.7
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/runtime@7.27.6': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -1194,6 +2369,1066 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.5.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.2':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.14':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@heroui/accordion@2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/divider': 2.2.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-accordion': 2.2.14-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tree': 3.9.0(react@18.2.0)
+      '@react-types/accordion': 3.0.0-alpha.26(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/alert@2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/aria-utils@2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@heroui/theme'
+      - framer-motion
+
+  '@heroui/autocomplete@2.3.23-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/input': 2.4.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/listbox': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/popover': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/scroll-shadow': 2.3.15-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/combobox': 3.12.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/combobox': 3.10.6(react@18.2.0)
+      '@react-types/combobox': 3.13.6(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@heroui/avatar@2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-image': 2.1.11-beta.2(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/badge@2.2.14-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/breadcrumbs@2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-aria/breadcrumbs': 3.5.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/breadcrumbs': 3.7.14(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/button@2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/ripple': 2.2.17-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/spinner': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-button': 2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/calendar@2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-button': 2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@internationalized/date': 3.8.2
+      '@react-aria/calendar': 3.8.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/calendar': 3.8.2(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/calendar': 3.7.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      scroll-into-view-if-needed: 3.0.10
+
+  '@heroui/card@2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/ripple': 2.2.17-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-button': 2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/checkbox@2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-callback-ref': 2.1.8-beta.4(react@18.2.0)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/checkbox': 3.15.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/checkbox': 3.6.15(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/chip@2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/code@2.2.17-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system-rsc': 2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/date-input@2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@internationalized/date': 3.8.2
+      '@react-aria/datepicker': 3.14.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/datepicker': 3.14.2(react@18.2.0)
+      '@react-types/datepicker': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/date-picker@2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/calendar': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/date-input': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/popover': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@internationalized/date': 3.8.2
+      '@react-aria/datepicker': 3.14.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/datepicker': 3.14.2(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/datepicker': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/divider@2.2.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-rsc-utils': 2.1.9-beta.2(react@18.2.0)
+      '@heroui/system-rsc': 2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/dom-animation@2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+
+  '@heroui/drawer@2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/modal': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/dropdown@2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/menu': 2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/popover': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/menu': 3.18.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/menu': 3.9.5(react@18.2.0)
+      '@react-types/menu': 3.10.2(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/form@2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-types/form': 3.7.13(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/framer-utils@2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-measure': 2.1.8-beta.4(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@heroui/theme'
+
+  '@heroui/image@2.2.14-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-image': 2.1.11-beta.2(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/input-otp@2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-form-reset': 2.0.0-beta.1(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/form': 3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/textfield': 3.12.3(react@18.2.0)
+      input-otp: 1.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/input@2.4.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/textfield': 3.17.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/textfield': 3.12.3(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-textarea-autosize: 8.5.9(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@heroui/kbd@2.2.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system-rsc': 2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/link@2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-link': 2.2.17-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/link': 3.6.2(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/listbox@2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/divider': 2.2.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-is-mobile': 2.2.11-beta.2(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/listbox': 3.14.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/list': 3.12.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@tanstack/react-virtual': 3.11.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/menu@2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/divider': 2.2.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-is-mobile': 2.2.11-beta.2(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/menu': 3.18.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tree': 3.9.0(react@18.2.0)
+      '@react-types/menu': 3.10.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/modal@2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-button': 2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-aria-modal-overlay': 2.2.15-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-disclosure': 2.2.14-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-draggable': 2.1.14-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-viewport-size': 2.0.0-beta.1(react@18.2.0)
+      '@react-aria/dialog': 3.5.27(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/navbar@2.2.20-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-resize': 2.1.8-beta.4(react@18.2.0)
+      '@heroui/use-scroll-position': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/button': 3.13.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/number-input@2.0.12-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/numberfield': 3.11.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/numberfield': 3.9.13(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/numberfield': 3.8.12(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/pagination@2.2.20-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-intersection-observer': 2.2.14-beta.2(react@18.2.0)
+      '@heroui/use-pagination': 2.2.15-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      scroll-into-view-if-needed: 3.0.10
+
+  '@heroui/popover@2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-button': 2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-aria-overlay': 2.0.1-beta.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/dialog': 3.5.27(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/progress@2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-is-mounted': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/progress': 3.4.24(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/progress': 3.5.13(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/radio@2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/radio': 3.11.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/radio': 3.10.14(react@18.2.0)
+      '@react-types/radio': 3.8.10(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/react-rsc-utils@2.1.9-beta.2(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/react-utils@2.1.12-beta.2(react@18.2.0)':
+    dependencies:
+      '@heroui/react-rsc-utils': 2.1.9-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      react: 18.2.0
+
+  '@heroui/react@2.8.0-beta.10(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(tailwindcss@4.1.11)':
+    dependencies:
+      '@heroui/accordion': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/alert': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/autocomplete': 2.3.23-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/avatar': 2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/badge': 2.2.14-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/breadcrumbs': 2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/calendar': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/card': 2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/checkbox': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/chip': 2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/code': 2.2.17-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/date-input': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/date-picker': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/divider': 2.2.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/drawer': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/dropdown': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/image': 2.2.14-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/input': 2.4.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/input-otp': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/kbd': 2.2.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/link': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/listbox': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/menu': 2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/modal': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/navbar': 2.2.20-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/number-input': 2.0.12-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/pagination': 2.2.20-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/popover': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/progress': 2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/radio': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/ripple': 2.2.17-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/scroll-shadow': 2.3.15-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/select': 2.4.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/skeleton': 2.2.14-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/slider': 2.4.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/snippet': 2.2.23-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/spacer': 2.2.17-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/spinner': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/switch': 2.2.20-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/table': 2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/tabs': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/toast': 2.0.12-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/tooltip': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/user': 2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - tailwindcss
+
+  '@heroui/ripple@2.2.17-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/scroll-shadow@2.3.15-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-data-scroll-overflow': 2.2.11-beta.4(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/select@2.4.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/form': 2.1.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/listbox': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/popover': 2.3.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/scroll-shadow': 2.3.15-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/spinner': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-button': 2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-aria-multiselect': 2.4.15-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-form-reset': 2.0.0-beta.1(react@18.2.0)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/form': 3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/shared-icons@2.1.10-beta.2(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/shared-utils@2.1.10-beta.4': {}
+
+  '@heroui/skeleton@2.2.14-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/slider@2.4.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/tooltip': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/slider': 3.7.21(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/slider': 3.6.5(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/snippet@2.2.23-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/button': 2.2.22-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/tooltip': 2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-clipboard': 2.1.9-beta.4(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/spacer@2.2.17-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system-rsc': 2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/spinner@2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/system-rsc': 2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - framer-motion
+
+  '@heroui/switch@2.2.20-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/switch': 3.7.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/system-rsc@2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)':
+    dependencies:
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      clsx: 1.2.1
+      react: 18.2.0
+
+  '@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/system-rsc': 2.3.16-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@heroui/theme'
+
+  '@heroui/table@2.2.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/checkbox': 2.3.21-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/spacer': 2.2.17-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/table': 3.17.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/table': 3.14.3(react@18.2.0)
+      '@react-stately/virtualizer': 4.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/grid': 3.3.3(react@18.2.0)
+      '@react-types/table': 3.13.1(react@18.2.0)
+      '@tanstack/react-virtual': 3.11.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/tabs@2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-is-mounted': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/tabs': 3.10.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tabs': 3.8.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      scroll-into-view-if-needed: 3.0.10
+
+  '@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11)':
+    dependencies:
+      '@heroui/shared-utils': 2.1.10-beta.4
+      clsx: 1.2.1
+      color: 4.2.3
+      color2k: 2.0.3
+      deepmerge: 4.3.1
+      flat: 5.0.2
+      tailwind-merge: 3.0.2
+      tailwind-variants: 1.0.0(tailwindcss@4.1.11)
+      tailwindcss: 4.1.11
+
+  '@heroui/toast@2.0.12-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-icons': 2.1.10-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/spinner': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-is-mobile': 2.2.11-beta.2(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/toast': 3.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toast': 3.1.1(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/tooltip@2.2.19-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/aria-utils': 2.2.19-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/dom-animation': 2.1.10-beta.2(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@heroui/framer-utils': 2.1.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@heroui/use-aria-overlay': 2.0.1-beta.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/tooltip': 3.8.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tooltip': 3.5.5(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/tooltip': 3.4.18(react@18.2.0)
+      framer-motion: 12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/use-aria-accordion@2.2.14-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/button': 3.13.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tree': 3.9.0(react@18.2.0)
+      '@react-types/accordion': 3.0.0-alpha.26(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@heroui/use-aria-button@2.2.16-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@heroui/use-aria-link@2.2.17-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/link': 3.6.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@heroui/use-aria-modal-overlay@2.2.15-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/use-aria-overlay': 2.0.1-beta.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/use-aria-multiselect@2.4.15-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/listbox': 3.14.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/menu': 3.18.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/list': 3.12.3(react@18.2.0)
+      '@react-stately/menu': 3.9.5(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/use-aria-overlay@2.0.1-beta.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@heroui/use-callback-ref@2.1.8-beta.4(react@18.2.0)':
+    dependencies:
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      react: 18.2.0
+
+  '@heroui/use-clipboard@2.1.9-beta.4(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-data-scroll-overflow@2.2.11-beta.4(react@18.2.0)':
+    dependencies:
+      '@heroui/shared-utils': 2.1.10-beta.4
+      react: 18.2.0
+
+  '@heroui/use-disclosure@2.2.14-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/use-callback-ref': 2.1.8-beta.4(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@heroui/use-draggable@2.1.14-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@heroui/use-form-reset@2.0.0-beta.1(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-image@2.1.11-beta.2(react@18.2.0)':
+    dependencies:
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/use-safe-layout-effect': 2.1.8-beta.4(react@18.2.0)
+      react: 18.2.0
+
+  '@heroui/use-intersection-observer@2.2.14-beta.2(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-is-mobile@2.2.11-beta.2(react@18.2.0)':
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@18.2.0)
+      react: 18.2.0
+
+  '@heroui/use-is-mounted@2.1.8-beta.4(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-measure@2.1.8-beta.4(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-pagination@2.2.15-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@heroui/use-resize@2.1.8-beta.4(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-safe-layout-effect@2.1.8-beta.4(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-scroll-position@2.1.8-beta.4(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/use-viewport-size@2.0.0-beta.1(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@heroui/user@2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@heroui/avatar': 2.2.18-beta.2(@heroui/system@2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/react-utils': 2.1.12-beta.2(react@18.2.0)
+      '@heroui/shared-utils': 2.1.10-beta.4
+      '@heroui/system': 2.4.18-beta.2(@heroui/theme@2.4.18-beta.2(tailwindcss@4.1.11))(framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@heroui/theme': 2.4.18-beta.2(tailwindcss@4.1.11)
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@internationalized/date@3.8.2':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
+  '@internationalized/message@3.1.8':
+    dependencies:
+      '@swc/helpers': 0.5.17
+      intl-messageformat: 10.7.16
+
+  '@internationalized/number@3.6.3':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
+  '@internationalized/string@3.2.7':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -1214,6 +3449,794 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@react-aria/breadcrumbs@3.5.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/link': 3.8.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/breadcrumbs': 3.7.14(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/button@3.13.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/toolbar': 3.0.0-beta.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/calendar@3.8.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/live-announcer': 3.4.3
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/calendar': 3.8.2(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/calendar': 3.7.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/checkbox@3.15.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/form': 3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/toggle': 3.11.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/checkbox': 3.6.15(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/combobox@3.12.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/listbox': 3.14.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/live-announcer': 3.4.3
+      '@react-aria/menu': 3.18.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/textfield': 3.17.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/combobox': 3.10.6(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/combobox': 3.13.6(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/datepicker@3.14.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@internationalized/number': 3.6.3
+      '@internationalized/string': 3.2.7
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/form': 3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/spinbutton': 3.6.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/datepicker': 3.14.2(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/calendar': 3.7.2(react@18.2.0)
+      '@react-types/datepicker': 3.12.2(react@18.2.0)
+      '@react-types/dialog': 3.5.19(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/dialog@3.5.27(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/dialog': 3.5.19(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/focus@3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/form@3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/grid@3.14.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/live-announcer': 3.4.3
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/grid': 3.11.3(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/grid': 3.3.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/i18n@3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@internationalized/message': 3.1.8
+      '@internationalized/number': 3.6.3
+      '@internationalized/string': 3.2.7
+      '@react-aria/ssr': 3.9.9(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/interactions@3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/flags': 3.1.2
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/label@3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/landmark@3.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-sync-external-store: 1.5.0(react@18.2.0)
+
+  '@react-aria/link@3.8.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/link': 3.6.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/listbox@3.14.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/list': 3.12.3(react@18.2.0)
+      '@react-types/listbox': 3.7.1(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/live-announcer@3.4.3':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
+  '@react-aria/menu@3.18.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/overlays': 3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/menu': 3.9.5(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-stately/tree': 3.9.0(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/menu': 3.10.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/numberfield@3.11.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/spinbutton': 3.6.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/textfield': 3.17.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/numberfield': 3.9.13(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/numberfield': 3.8.12(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/overlays@3.27.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/ssr': 3.9.9(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/progress@3.4.24(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/progress': 3.5.13(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/radio@3.11.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/form': 3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/radio': 3.10.14(react@18.2.0)
+      '@react-types/radio': 3.8.10(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/selection@3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/slider@3.7.21(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/slider': 3.6.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/slider': 3.7.12(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/spinbutton@3.6.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/live-announcer': 3.4.3
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/ssr@3.9.9(react@18.2.0)':
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-aria/switch@3.7.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/toggle': 3.11.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/switch': 3.5.12(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/table@3.17.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/grid': 3.14.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/live-announcer': 3.4.3
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/visually-hidden': 3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/flags': 3.1.2
+      '@react-stately/table': 3.14.3(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/grid': 3.3.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/table': 3.13.1(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/tabs@3.10.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/selection': 3.24.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tabs': 3.8.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/tabs': 3.3.16(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/textfield@3.17.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/form': 3.0.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/label': 3.7.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/textfield': 3.12.3(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/toast@3.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/landmark': 3.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toast': 3.1.1(react@18.2.0)
+      '@react-types/button': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/toggle@3.11.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/toggle': 3.8.5(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/toolbar@3.0.0-beta.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/focus': 3.20.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/i18n': 3.12.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/tooltip@3.8.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-stately/tooltip': 3.5.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/tooltip': 3.4.18(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/utils@3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/ssr': 3.9.9(react@18.2.0)
+      '@react-stately/flags': 3.1.2
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-aria/visually-hidden@3.8.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/interactions': 3.25.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-stately/calendar@3.8.2(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/calendar': 3.7.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/checkbox@3.6.15(react@18.2.0)':
+    dependencies:
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/collections@3.12.5(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/combobox@3.10.6(react@18.2.0)':
+    dependencies:
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/list': 3.12.3(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-stately/select': 3.6.14(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/combobox': 3.13.6(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/datepicker@3.14.2(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@internationalized/string': 3.2.7
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/datepicker': 3.12.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/flags@3.1.2':
+    dependencies:
+      '@swc/helpers': 0.5.17
+
+  '@react-stately/form@3.1.5(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/grid@3.11.3(react@18.2.0)':
+    dependencies:
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-types/grid': 3.3.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/list@3.12.3(react@18.2.0)':
+    dependencies:
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/menu@3.9.5(react@18.2.0)':
+    dependencies:
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-types/menu': 3.10.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/numberfield@3.9.13(react@18.2.0)':
+    dependencies:
+      '@internationalized/number': 3.6.3
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/numberfield': 3.8.12(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/overlays@3.6.17(react@18.2.0)':
+    dependencies:
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/radio@3.10.14(react@18.2.0)':
+    dependencies:
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/radio': 3.8.10(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/select@3.6.14(react@18.2.0)':
+    dependencies:
+      '@react-stately/form': 3.1.5(react@18.2.0)
+      '@react-stately/list': 3.12.3(react@18.2.0)
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-types/select': 3.9.13(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/selection@3.20.3(react@18.2.0)':
+    dependencies:
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/slider@3.6.5(react@18.2.0)':
+    dependencies:
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/slider': 3.7.12(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/table@3.14.3(react@18.2.0)':
+    dependencies:
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/flags': 3.1.2
+      '@react-stately/grid': 3.11.3(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/grid': 3.3.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/table': 3.13.1(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/tabs@3.8.3(react@18.2.0)':
+    dependencies:
+      '@react-stately/list': 3.12.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@react-types/tabs': 3.3.16(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/toast@3.1.1(react@18.2.0)':
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      use-sync-external-store: 1.5.0(react@18.2.0)
+
+  '@react-stately/toggle@3.8.5(react@18.2.0)':
+    dependencies:
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/checkbox': 3.9.5(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/tooltip@3.5.5(react@18.2.0)':
+    dependencies:
+      '@react-stately/overlays': 3.6.17(react@18.2.0)
+      '@react-types/tooltip': 3.4.18(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/tree@3.9.0(react@18.2.0)':
+    dependencies:
+      '@react-stately/collections': 3.12.5(react@18.2.0)
+      '@react-stately/selection': 3.20.3(react@18.2.0)
+      '@react-stately/utils': 3.10.7(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/utils@3.10.7(react@18.2.0)':
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+
+  '@react-stately/virtualizer@4.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-aria/utils': 3.29.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      '@swc/helpers': 0.5.17
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@react-types/accordion@3.0.0-alpha.26(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/breadcrumbs@3.7.14(react@18.2.0)':
+    dependencies:
+      '@react-types/link': 3.6.2(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/button@3.12.2(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/calendar@3.7.2(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/checkbox@3.9.5(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/combobox@3.13.6(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/datepicker@3.12.2(react@18.2.0)':
+    dependencies:
+      '@internationalized/date': 3.8.2
+      '@react-types/calendar': 3.7.2(react@18.2.0)
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/dialog@3.5.19(react@18.2.0)':
+    dependencies:
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/form@3.7.13(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/grid@3.3.3(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/link@3.6.2(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/listbox@3.7.1(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/menu@3.10.2(react@18.2.0)':
+    dependencies:
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/numberfield@3.8.12(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/overlays@3.8.16(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/progress@3.5.13(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/radio@3.8.10(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/select@3.9.13(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/shared@3.30.0(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+
+  '@react-types/slider@3.7.12(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/switch@3.5.12(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/table@3.13.1(react@18.2.0)':
+    dependencies:
+      '@react-types/grid': 3.3.3(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/tabs@3.3.16(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/textfield@3.12.3(react@18.2.0)':
+    dependencies:
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
+
+  '@react-types/tooltip@3.4.18(react@18.2.0)':
+    dependencies:
+      '@react-types/overlays': 3.8.16(react@18.2.0)
+      '@react-types/shared': 3.30.0(react@18.2.0)
+      react: 18.2.0
 
   '@rolldown/pluginutils@1.0.0-beta.19': {}
 
@@ -1276,6 +4299,10 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.44.1':
     optional: true
+
+  '@swc/helpers@0.5.17':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -1347,6 +4374,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
       vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+
+  '@tanstack/react-virtual@3.11.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.11.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@tanstack/virtual-core@3.11.3': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1426,15 +4461,33 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@1.2.1: {}
+
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+
+  color2k@2.0.3: {}
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  compute-scroll-into-view@3.1.1: {}
 
   concurrently@9.2.0:
     dependencies:
@@ -1451,6 +4504,10 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.5.0: {}
+
+  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -1520,6 +4577,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  flat@5.0.2: {}
+
   follow-redirects@1.15.9: {}
 
   form-data@4.0.3:
@@ -1529,6 +4588,15 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  framer-motion@12.19.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      motion-dom: 12.19.0
+      motion-utils: 12.19.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   fsevents@2.3.3:
     optional: true
@@ -1574,6 +4642,20 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  input-otp@1.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  intl-messageformat@10.7.16:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      tslib: 2.8.1
+
+  is-arrayish@0.3.2: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -1666,6 +4748,12 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  motion-dom@12.19.0:
+    dependencies:
+      motion-utils: 12.19.0
+
+  motion-utils@12.19.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1693,6 +4781,15 @@ snapshots:
       scheduler: 0.23.2
 
   react-refresh@0.17.0: {}
+
+  react-textarea-autosize@8.5.9(react@18.2.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      react: 18.2.0
+      use-composed-ref: 1.4.0(react@18.2.0)
+      use-latest: 1.3.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react@18.2.0:
     dependencies:
@@ -1734,9 +4831,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scroll-into-view-if-needed@3.0.10:
+    dependencies:
+      compute-scroll-into-view: 3.1.1
+
   semver@6.3.1: {}
 
   shell-quote@1.8.3: {}
+
+  simple-swizzle@0.2.2:
+    dependencies:
+      is-arrayish: 0.3.2
 
   source-map-js@1.2.1: {}
 
@@ -1757,6 +4862,13 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  tailwind-merge@3.0.2: {}
+
+  tailwind-variants@1.0.0(tailwindcss@4.1.11):
+    dependencies:
+      tailwind-merge: 3.0.2
+      tailwindcss: 4.1.11
 
   tailwindcss@4.1.11: {}
 
@@ -1785,6 +4897,23 @@ snapshots:
       browserslist: 4.25.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-composed-ref@1.4.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
+  use-isomorphic-layout-effect@1.2.1(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
+  use-latest@1.3.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      use-isomorphic-layout-effect: 1.2.1(react@18.2.0)
+
+  use-sync-external-store@1.5.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   vite-plugin-full-reload@1.2.0:
     dependencies:

--- a/diversionrp-laravel/resources/js/components/Home.jsx
+++ b/diversionrp-laravel/resources/js/components/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from '@heroui/react';
 
 export default function Home() {
   return (
@@ -21,9 +22,7 @@ export default function Home() {
         </h1>
         <p className="mt-6 text-lg text-gray-300">We're moving to React.</p>
         <a href="https://discord.gg/diversionrp" target="_blank" rel="noreferrer">
-          <button className="mt-8 bg-gradient-to-r from-teal-400 to-blue-500 px-6 py-2 rounded-full shadow-lg hover:from-blue-600 hover:to-teal-500">
-            Join Today!
-          </button>
+          <Button color="primary" className="mt-8 rounded-full">Join Today!</Button>
         </a>
       </main>
     </div>

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.41",
-    "tailwindcss": "^3.4.10"
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.11",
+    "tailwindcss-cli": "^0.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,42 +9,27 @@ importers:
   .:
     devDependencies:
       autoprefixer:
-        specifier: ^10.4.20
+        specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
       postcss:
-        specifier: ^8.4.41
+        specifier: ^8.5.6
         version: 8.5.6
       tailwindcss:
-        specifier: ^3.4.10
-        version: 3.4.17
+        specifier: ^4.1.11
+        version: 4.1.11
+      tailwindcss-cli:
+        specifier: ^0.1.2
+        version: 0.1.2
 
 packages:
 
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -58,28 +43,24 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
+  '@types/parse-json@4.0.2':
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+  acorn-node@1.8.2:
+    resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
 
-  ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
-    engines: {node: '>=12'}
+  acorn-walk@7.2.0:
+    resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@7.4.1:
+    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -102,8 +83,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -114,12 +95,24 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
   caniuse-lite@1.0.30001726:
     resolution: {integrity: sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -132,17 +125,41 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
 
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+
+  css-color-names@0.0.4:
+    resolution: {integrity: sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==}
+
+  css-unit-converter@1.1.2:
+    resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  defined@1.0.1:
+    resolution: {integrity: sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==}
+
+  detective@5.2.1:
+    resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
+    engines: {node: '>=0.8.0'}
     hasBin: true
 
   didyoumean@1.2.2:
@@ -151,17 +168,11 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   electron-to-chromium@1.5.177:
     resolution: {integrity: sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -178,12 +189,15 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -201,17 +215,57 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hex-color-regex@1.1.0:
+    resolution: {integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==}
+
+  hsl-regex@1.0.0:
+    resolution: {integrity: sha512-M5ezZw4LzXbBKMruP+BNANf0k+19hDQMgpzBIYnya//Al+fjNct9Wf3b1WedLqdEs2hKBvxq/jh+DsHJLj0F9A==}
+
+  hsla-regex@1.0.0:
+    resolution: {integrity: sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA==}
+
+  html-tags@3.3.1:
+    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
+    engines: {node: '>=8'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-arrayish@0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-color-stop@1.1.0:
+    resolution: {integrity: sha512-H1U8Vz0cfXNujrJzEcvvwMDW9Ra+biSYA3ThdQvAnMLJkEHQXn6bWzLkxHtVYJ+Sdbx0b6finn3jZiaVe7MAHA==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -221,10 +275,6 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -233,25 +283,27 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+  lodash.topath@4.5.2:
+    resolution: {integrity: sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -261,21 +313,23 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+  modern-normalize@1.1.0:
+    resolution: {integrity: sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==}
+    engines: {node: '>=6'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-emoji@1.11.0:
+    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -288,27 +342,31 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -317,29 +375,13 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
+  postcss-js@3.0.3:
+    resolution: {integrity: sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==}
+    engines: {node: '>=10.0'}
 
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.0.1:
-    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
+  postcss-load-config@3.1.4:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
     peerDependencies:
       postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
@@ -349,8 +391,8 @@ packages:
       ts-node:
         optional: true
 
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+  postcss-nested@5.0.6:
+    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
@@ -359,6 +401,9 @@ packages:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
 
+  postcss-value-parser@3.3.1:
+    resolution: {integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -366,15 +411,31 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-hrtime@1.0.3:
+    resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
+    engines: {node: '>= 0.8'}
+
+  purgecss@4.1.3:
+    resolution: {integrity: sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==}
+    hasBin: true
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  reduce-css-calc@2.1.8:
+    resolution: {integrity: sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
 
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
@@ -385,68 +446,56 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rgb-regex@1.0.1:
+    resolution: {integrity: sha512-gDK5mkALDFER2YLqH6imYvK6g02gpNGM4ILDZ472EwWfXZnC2ZEpoB2ECXTyOVUKuk/bPJZMzwQPBYICzP+D3w==}
+
+  rgba-regex@1.0.0:
+    resolution: {integrity: sha512-zgn5OjNQXLUTdq8m17KdaicF6w89TZs8ZU8y0AYENIU6wG8GG6LLm0yLSiPY8DmaYmHdgRW8rnApjoT0fQRfMg==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+  simple-swizzle@0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-
-  sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
-    engines: {node: '>=14.0.0'}
+  tailwindcss-cli@0.1.2:
+    resolution: {integrity: sha512-17NuGSHKTr4twN1BFxuoTArMcBQH+7YL6x4PHFnmWsGNOX45O4Roc8EdMVhSSH2rQoSDoLvR4TmlfddMon3yKg==}
     hasBin: true
 
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
+  tailwindcss@2.2.19:
+    resolution: {integrity: sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      autoprefixer: ^10.0.2
+      postcss: ^8.0.9
 
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+  tailwindcss@4.1.11:
+    resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
+
+  tmp@0.2.3:
+    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -457,53 +506,26 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
 
 snapshots:
 
-  '@alloc/quick-lru@5.2.0': {}
-
-  '@isaacs/cliui@8.0.2':
+  '@babel/code-frame@7.27.1':
     dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
-  '@jridgewell/gen-mapping@0.3.8':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-
-  '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/set-array@1.2.1': {}
-
-  '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -517,20 +539,21 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
+  '@types/parse-json@4.0.2': {}
 
-  ansi-regex@5.0.1: {}
+  acorn-node@1.8.2:
+    dependencies:
+      acorn: 7.4.1
+      acorn-walk: 7.2.0
+      xtend: 4.0.2
 
-  ansi-regex@6.1.0: {}
+  acorn-walk@7.2.0: {}
+
+  acorn@7.4.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@6.2.1: {}
-
-  any-promise@1.3.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -553,9 +576,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   braces@3.0.3:
     dependencies:
@@ -568,9 +592,18 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
+  bytes@3.1.2: {}
+
+  callsites@3.1.0: {}
+
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001726: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chokidar@3.6.0:
     dependencies:
@@ -590,27 +623,51 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  commander@4.1.1: {}
-
-  cross-spawn@7.0.6:
+  color-string@1.9.1:
     dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
+  commander@8.3.0: {}
+
+  concat-map@0.0.1: {}
+
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+
+  css-color-names@0.0.4: {}
+
+  css-unit-converter@1.1.2: {}
 
   cssesc@3.0.0: {}
+
+  defined@1.0.1: {}
+
+  detective@5.2.1:
+    dependencies:
+      acorn-node: 1.8.2
+      defined: 1.0.1
+      minimist: 1.2.8
 
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
 
-  eastasianwidth@0.2.0: {}
-
   electron-to-chromium@1.5.177: {}
 
-  emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
 
   escalade@3.2.0: {}
 
@@ -630,12 +687,15 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   fraction.js@4.3.7: {}
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -650,22 +710,59 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.4.5:
+  glob@7.2.3:
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
+  hex-color-regex@1.1.0: {}
+
+  hsl-regex@1.0.0: {}
+
+  hsla-regex@1.0.0: {}
+
+  html-tags@3.3.1: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-arrayish@0.3.2: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-color-stop@1.1.0:
+    dependencies:
+      css-color-names: 0.0.4
+      hex-color-regex: 1.1.0
+      hsl-regex: 1.0.0
+      hsla-regex: 1.0.0
+      rgb-regex: 1.0.1
+      rgba-regex: 1.0.0
 
   is-core-module@2.16.1:
     dependencies:
@@ -673,29 +770,29 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
-  is-fullwidth-code-point@3.0.0: {}
-
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
 
-  isexe@2.0.0: {}
+  js-tokens@4.0.0: {}
 
-  jackspeak@3.4.3:
+  json-parse-even-better-errors@2.3.1: {}
+
+  jsonfile@6.1.0:
     dependencies:
-      '@isaacs/cliui': 8.0.2
+      universalify: 2.0.1
     optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
+      graceful-fs: 4.2.11
 
-  jiti@1.21.7: {}
-
-  lilconfig@3.1.3: {}
+  lilconfig@2.1.0: {}
 
   lines-and-columns@1.2.4: {}
 
-  lru-cache@10.4.3: {}
+  lodash.topath@4.5.2: {}
+
+  lodash@4.17.21: {}
 
   merge2@1.4.1: {}
 
@@ -704,19 +801,19 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  minimatch@9.0.5:
+  minimatch@3.1.2:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 1.1.12
 
-  minipass@7.1.2: {}
+  minimist@1.2.8: {}
 
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
+  modern-normalize@1.1.0: {}
 
   nanoid@3.3.11: {}
+
+  node-emoji@1.11.0:
+    dependencies:
+      lodash: 4.17.21
 
   node-releases@2.0.19: {}
 
@@ -724,49 +821,46 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
-  object-assign@4.1.1: {}
+  object-hash@2.2.0: {}
 
-  object-hash@3.0.0: {}
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
-  package-json-from-dist@1.0.1: {}
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
 
-  path-key@3.1.1: {}
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  path-is-absolute@1.0.1: {}
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
+  path-type@4.0.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
-  pify@2.3.0: {}
-
-  pirates@4.0.7: {}
-
-  postcss-import@15.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-
-  postcss-js@4.0.1(postcss@8.5.6):
+  postcss-js@3.0.3:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@4.0.2(postcss@8.5.6):
+  postcss-load-config@3.1.4(postcss@8.5.6):
     dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.0
+      lilconfig: 2.1.0
+      yaml: 1.10.2
     optionalDependencies:
       postcss: 8.5.6
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@5.0.6(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
@@ -776,6 +870,8 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
+  postcss-value-parser@3.3.1: {}
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
@@ -784,15 +880,29 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-hrtime@1.0.3: {}
+
+  purgecss@4.1.3:
+    dependencies:
+      commander: 8.3.0
+      glob: 7.2.3
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   queue-microtask@1.2.3: {}
 
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
+  quick-lru@5.1.1: {}
 
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  reduce-css-calc@2.1.8:
+    dependencies:
+      css-unit-converter: 1.1.2
+      postcss-value-parser: 3.3.1
+
+  resolve-from@4.0.0: {}
 
   resolve@1.22.10:
     dependencies:
@@ -802,92 +912,82 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rgb-regex@1.0.1: {}
+
+  rgba-regex@1.0.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
-  shebang-command@2.0.0:
+  simple-swizzle@0.2.2:
     dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  signal-exit@4.1.0: {}
+      is-arrayish: 0.3.2
 
   source-map-js@1.2.1: {}
 
-  string-width@4.2.3:
+  supports-color@7.2.0:
     dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.1.0:
-    dependencies:
-      ansi-regex: 6.1.0
-
-  sucrase@3.35.0:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      commander: 4.1.1
-      glob: 10.4.5
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.7
-      ts-interface-checker: 0.1.13
+      has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.17:
+  tailwindcss-cli@0.1.2:
     dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
+      autoprefixer: 10.4.21(postcss@8.5.6)
       postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
+      tailwindcss: 2.2.19(autoprefixer@10.4.21(postcss@8.5.6))(postcss@8.5.6)
     transitivePeerDependencies:
       - ts-node
 
-  thenify-all@1.6.0:
+  tailwindcss@2.2.19(autoprefixer@10.4.21(postcss@8.5.6))(postcss@8.5.6):
     dependencies:
-      thenify: 3.3.1
+      arg: 5.0.2
+      autoprefixer: 10.4.21(postcss@8.5.6)
+      bytes: 3.1.2
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      color: 4.2.3
+      cosmiconfig: 7.1.0
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      fs-extra: 10.1.0
+      glob-parent: 6.0.2
+      html-tags: 3.3.1
+      is-color-stop: 1.1.0
+      is-glob: 4.0.3
+      lodash: 4.17.21
+      lodash.topath: 4.5.2
+      modern-normalize: 1.1.0
+      node-emoji: 1.11.0
+      normalize-path: 3.0.0
+      object-hash: 2.2.0
+      postcss: 8.5.6
+      postcss-js: 3.0.3
+      postcss-load-config: 3.1.4(postcss@8.5.6)
+      postcss-nested: 5.0.6(postcss@8.5.6)
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+      pretty-hrtime: 1.0.3
+      purgecss: 4.1.3
+      quick-lru: 5.1.1
+      reduce-css-calc: 2.1.8
+      resolve: 1.22.10
+      tmp: 0.2.3
+    transitivePeerDependencies:
+      - ts-node
 
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
+  tailwindcss@4.1.11: {}
+
+  tmp@0.2.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  ts-interface-checker@0.1.13: {}
+  universalify@2.0.1: {}
 
   update-browserslist-db@1.1.3(browserslist@4.25.1):
     dependencies:
@@ -897,20 +997,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
+  wrappy@1.0.2: {}
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
+  xtend@4.0.2: {}
 
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
-
-  yaml@2.8.0: {}
+  yaml@1.10.2: {}


### PR DESCRIPTION
## Summary
- update build instructions in AGENTS.md
- bump Tailwind CSS to v4 and add CLI
- install `@heroui/react` for the Laravel React frontend
- use a HeroUI `Button` component on the home page
- document Tailwind 4 and HeroUI usage in README

## Testing
- `pnpm exec tailwindcss-cli -i ./src/styles.css -o ./dist/styles.css`
- `cd diversionrp-laravel && pnpm run build`
- `php -l db.php posts.php showcase.php` *(fails: command not found)*
- `tidy -qe *.html` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7638cf908330a26373896a060d77